### PR TITLE
Feat/my pokemons module

### DIFF
--- a/src/allPokemons/all-pokemons.controller.ts
+++ b/src/allPokemons/all-pokemons.controller.ts
@@ -4,41 +4,12 @@ import {
   Param,
   Query,
   NotFoundException,
-  InternalServerErrorException,
-  BadRequestException,
   Logger,
 } from '@nestjs/common';
 import { AllPokemonsService } from './all-pokemons.service';
 import { Pokemon } from '../types/pokemon.types';
-
-enum ControllerErrorType {
-  CastError = 'CastError',
-  ValidationError = 'ValidationError',
-  NotFoundException = 'NotFoundException',
-}
-
-function handleControllerError(
-  error: Error,
-  logger: Logger,
-  notFoundMsg?: string,
-  badRequestMsg?: string,
-  internalMsg?: string,
-): never {
-  logger.error(error.message, error.stack);
-  switch (error.name) {
-    case ControllerErrorType.CastError:
-    case ControllerErrorType.ValidationError:
-      throw new BadRequestException(
-        badRequestMsg || 'Invalid request parameters',
-      );
-    case ControllerErrorType.NotFoundException:
-      throw new NotFoundException(notFoundMsg || 'Resource not found');
-    default:
-      throw new InternalServerErrorException(
-        internalMsg || 'Internal server error',
-      );
-  }
-}
+import { ControllerErrorType } from '../common/controller-error-type.enum';
+import { handleControllerError } from '../common/handle-controller-error';
 
 @Controller('all-pokemons')
 export class AllPokemonsController {
@@ -55,13 +26,17 @@ export class AllPokemonsController {
     @Query('search') search?: string,
   ): Promise<Pokemon[]> {
     try {
-      return await this.service.getAll(
+      const result = await this.service.getAll(
         limit ? Number(limit) : undefined,
         offset ? Number(offset) : undefined,
         sort,
         order,
         search,
       );
+      this.logger.log(
+        `Fetched all pokemons (count: ${result.length}) with params: limit=${limit}, offset=${offset}, sort=${sort}, order=${order}, search=${search}`,
+      );
+      return result;
     } catch (error) {
       handleControllerError(
         error,
@@ -77,6 +52,7 @@ export class AllPokemonsController {
   async count(): Promise<{ count: number }> {
     try {
       const count = await this.service.count();
+      this.logger.log(`Fetched pokemons count: ${count}`);
       return { count };
     } catch (error) {
       handleControllerError(
@@ -96,6 +72,7 @@ export class AllPokemonsController {
       if (!pokemon) {
         throw new NotFoundException(`Pokemon with id ${id} not found`);
       }
+      this.logger.log(`Fetched pokemon with id: ${id}`);
       return pokemon;
     } catch (error) {
       handleControllerError(

--- a/src/allPokemons/all-pokemons.controller.ts
+++ b/src/allPokemons/all-pokemons.controller.ts
@@ -1,9 +1,49 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  NotFoundException,
+  InternalServerErrorException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
 import { AllPokemonsService } from './all-pokemons.service';
 import { Pokemon } from '../types/pokemon.types';
 
+enum ControllerErrorType {
+  CastError = 'CastError',
+  ValidationError = 'ValidationError',
+  NotFoundException = 'NotFoundException',
+}
+
+function handleControllerError(
+  error: Error,
+  logger: Logger,
+  notFoundMsg?: string,
+  badRequestMsg?: string,
+  internalMsg?: string,
+): never {
+  logger.error(error.message, error.stack);
+  switch (error.name) {
+    case ControllerErrorType.CastError:
+    case ControllerErrorType.ValidationError:
+      throw new BadRequestException(
+        badRequestMsg || 'Invalid request parameters',
+      );
+    case ControllerErrorType.NotFoundException:
+      throw new NotFoundException(notFoundMsg || 'Resource not found');
+    default:
+      throw new InternalServerErrorException(
+        internalMsg || 'Internal server error',
+      );
+  }
+}
+
 @Controller('all-pokemons')
 export class AllPokemonsController {
+  private readonly logger = new Logger(AllPokemonsController.name);
+
   constructor(private readonly service: AllPokemonsService) {}
 
   @Get()
@@ -14,22 +54,57 @@ export class AllPokemonsController {
     @Query('order') order?: string,
     @Query('search') search?: string,
   ): Promise<Pokemon[]> {
-    return this.service.getAll(
-      limit ? Number(limit) : undefined,
-      offset ? Number(offset) : undefined,
-      sort,
-      order,
-      search,
-    );
+    try {
+      return await this.service.getAll(
+        limit ? Number(limit) : undefined,
+        offset ? Number(offset) : undefined,
+        sort,
+        order,
+        search,
+      );
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid query parameters',
+        'Failed to fetch pokemons',
+      );
+    }
   }
+
   @Get('count')
   async count(): Promise<{ count: number }> {
-    const count = await this.service.count();
-    return { count };
+    try {
+      const count = await this.service.count();
+      return { count };
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid query parameters',
+        'Failed to fetch pokemons count',
+      );
+    }
   }
 
   @Get(':id')
   async getById(@Param('id') id: string): Promise<Pokemon | null> {
-    return this.service.getById(Number(id));
+    try {
+      const pokemon = await this.service.getById(Number(id));
+      if (!pokemon) {
+        throw new NotFoundException(`Pokemon with id ${id} not found`);
+      }
+      return pokemon;
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        `Pokemon with id ${id} not found`,
+        'Invalid ID parameter',
+        'Failed to fetch pokemon',
+      );
+    }
   }
 }

--- a/src/allPokemons/all-pokemons.repo.ts
+++ b/src/allPokemons/all-pokemons.repo.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, FilterQuery } from 'mongoose';
 import { Pokemon } from '../types/pokemon.types';
 
 @Injectable()
@@ -17,7 +17,7 @@ export class AllPokemonsRepo {
     order?: string,
     search?: string,
   ) {
-    let filter: any = {};
+    let filter: FilterQuery<Pokemon> = {};
     if (search) {
       filter.name = { $regex: search, $options: 'i' };
     }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,11 +3,16 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
 import { AllPokemonsModule } from './allPokemons/all-pokemons.module';
-import { MongooseModule } from '@nestjs/mongoose';
 import { MyPokemonsModule } from './myPokemons/my-pokemons.module';
+import { FightModule } from './fight/fight.module';
 
 @Module({
-  imports: [DatabaseModule, AllPokemonsModule, MyPokemonsModule],
+  imports: [
+    DatabaseModule,
+    AllPokemonsModule,
+    MyPokemonsModule,
+    FightModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
 import { AllPokemonsModule } from './allPokemons/all-pokemons.module';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MyPokemonsModule } from './myPokemons/my-pokemons.module';
 
 @Module({
-  imports: [DatabaseModule, AllPokemonsModule],
+  imports: [DatabaseModule, AllPokemonsModule, MyPokemonsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/common/controller-error-type.enum.ts
+++ b/src/common/controller-error-type.enum.ts
@@ -1,0 +1,5 @@
+export enum ControllerErrorType {
+  CastError = 'CastError',
+  ValidationError = 'ValidationError',
+  NotFoundException = 'NotFoundException',
+}

--- a/src/common/handle-controller-error.ts
+++ b/src/common/handle-controller-error.ts
@@ -1,0 +1,30 @@
+import {
+  NotFoundException,
+  InternalServerErrorException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { ControllerErrorType } from './controller-error-type.enum';
+
+export function handleControllerError(
+  error: Error,
+  logger: Logger,
+  notFoundMsg?: string,
+  badRequestMsg?: string,
+  internalMsg?: string,
+): never {
+  logger.error(error.message, error.stack);
+  switch (error.name) {
+    case ControllerErrorType.CastError:
+    case ControllerErrorType.ValidationError:
+      throw new BadRequestException(
+        badRequestMsg || 'Invalid request parameters',
+      );
+    case ControllerErrorType.NotFoundException:
+      throw new NotFoundException(notFoundMsg || 'Resource not found');
+    default:
+      throw new InternalServerErrorException(
+        internalMsg || 'Internal server error',
+      );
+  }
+}

--- a/src/fight/dto/attack.dto.ts
+++ b/src/fight/dto/attack.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class AttackDto {
+  @IsString()
+  fightId: string;
+
+  @IsString()
+  move: string;
+}

--- a/src/fight/dto/catch.dto.ts
+++ b/src/fight/dto/catch.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CatchDto {
+  @IsString()
+  fightId: string;
+}

--- a/src/fight/dto/start-fight.dto.ts
+++ b/src/fight/dto/start-fight.dto.ts
@@ -1,0 +1,6 @@
+import { IsNumber } from 'class-validator';
+
+export class StartFightDto {
+  @IsNumber()
+  userPokemonId: number;
+}

--- a/src/fight/fight.controller.ts
+++ b/src/fight/fight.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Post, Body, Logger } from '@nestjs/common';
+import { FightService } from './fight.service';
+import { StartFightDto } from './dto/start-fight.dto';
+import { AttackDto } from './dto/attack.dto';
+import { CatchDto } from './dto/catch.dto';
+import { handleControllerError } from '../common/handle-controller-error';
+
+@Controller('fight')
+export class FightController {
+  private readonly logger = new Logger(FightController.name);
+
+  constructor(private readonly service: FightService) {}
+
+  @Post('start')
+  async startFight(@Body() dto: StartFightDto) {
+    try {
+      return await this.service.startFight(dto);
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid start fight parameters',
+        'Failed to start fight',
+      );
+    }
+  }
+
+  @Post('attack')
+  async attack(@Body() dto: AttackDto) {
+    try {
+      return await this.service.attack(dto);
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid attack parameters',
+        'Failed to process attack',
+      );
+    }
+  }
+
+  @Post('catch')
+  async catchPokemon(@Body() dto: CatchDto) {
+    try {
+      return await this.service.catchPokemon(dto);
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid catch parameters',
+        'Failed to process catch',
+      );
+    }
+  }
+}

--- a/src/fight/fight.module.ts
+++ b/src/fight/fight.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { FightService } from './fight.service';
+import { FightController } from './fight.controller';
+import { FightRepo } from './fight.repo';
+import { MyPokemonsModule } from '../myPokemons/my-pokemons.module';
+import { AllPokemonsModule } from '../allPokemons/all-pokemons.module';
+import { FightSchema } from './fight.schema';
+
+@Module({
+  imports: [
+    MyPokemonsModule,
+    AllPokemonsModule,
+    MongooseModule.forFeature([{ name: 'Fight', schema: FightSchema }]),
+  ],
+  providers: [FightService, FightRepo],
+  controllers: [FightController],
+})
+export class FightModule {}

--- a/src/fight/fight.repo.ts
+++ b/src/fight/fight.repo.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, FilterQuery } from 'mongoose';
+import { BattleLogEntry } from './fight.schema';
+import { Pokemon } from 'src/types/pokemon.types';
+
+export type FightState = {
+  fightId: string;
+  userPokemon: Pokemon;
+  opponentPokemon: Pokemon;
+  userPokemonHP: number;
+  opponentPokemonHP: number;
+  turn: string;
+  battleLog: BattleLogEntry[];
+  winnerId: number | null;
+  status: string;
+};
+
+@Injectable()
+export class FightRepo {
+  constructor(
+    @InjectModel('Fight') private readonly fightModel: Model<FightState>,
+  ) {}
+
+  async createFight(fight: FightState) {
+    const created = new this.fightModel(fight);
+    return created.save();
+  }
+
+  async getFight(fightId: string): Promise<FightState | null> {
+    return this.fightModel.findOne({ fightId }).exec();
+  }
+
+  async updateFight(fightId: string, update: Partial<FightState>) {
+    return this.fightModel
+      .findOneAndUpdate({ fightId }, update, { new: true })
+      .exec();
+  }
+
+  async deleteFight(fightId: string) {
+    return this.fightModel.deleteOne({ fightId }).exec();
+  }
+}

--- a/src/fight/fight.schema.ts
+++ b/src/fight/fight.schema.ts
@@ -1,0 +1,32 @@
+import { Schema } from 'mongoose';
+
+export type BattleLogEntry = {
+  turn: string;
+  move: string;
+  damage: number;
+  result: string;
+  timestamp: Date;
+};
+
+export const FightSchema = new Schema({
+  fightId: { type: String, required: true, unique: true },
+  userPokemon: { type: Object, required: true },
+  opponentPokemon: { type: Object, required: true },
+  userPokemonHP: { type: Number, required: true },
+  opponentPokemonHP: { type: Number, required: true },
+  turn: { type: String, required: true },
+  battleLog: {
+    type: [
+      {
+        turn: String,
+        move: String,
+        damage: Number,
+        result: String,
+        timestamp: Date,
+      },
+    ],
+    default: [],
+  },
+  winnerId: { type: Number, default: null },
+  status: { type: String, default: 'in-progress' },
+});

--- a/src/fight/fight.service.ts
+++ b/src/fight/fight.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { StartFightDto } from './dto/start-fight.dto';
+import { AttackDto } from './dto/attack.dto';
+import { CatchDto } from './dto/catch.dto';
+import { FightRepo, FightState } from './fight.repo';
+import { randomUUID } from 'crypto';
+import { MyPokemonsService } from '../myPokemons/my-pokemons.service';
+import { AllPokemonsService } from '../allPokemons/all-pokemons.service';
+import { calculateNewLifeBar } from '../utiles/calculateNewLifeBar';
+import { updateFightAfterAttack } from '../utiles/updateFightAfterAttack';
+import { getRandomOpponentPokemon } from '../utiles/getRandomOpponentPokemon';
+
+@Injectable()
+export class FightService {
+  private readonly logger = new Logger(FightService.name);
+
+  constructor(
+    private readonly fightRepo: FightRepo,
+    private readonly myPokemonsService: MyPokemonsService,
+    private readonly allPokemonsService: AllPokemonsService,
+  ) {}
+
+  async startFight(dto: StartFightDto) {
+    try {
+      const userPokemon = await this.myPokemonsService.getById(
+        dto.userPokemonId,
+      );
+      if (!userPokemon) {
+        this.logger.error('User pokemon not found');
+        throw new NotFoundException('User pokemon not found');
+      }
+
+      const opponentPokemon = await getRandomOpponentPokemon(
+        this.myPokemonsService,
+        this.allPokemonsService,
+      );
+
+      const userPokemonHP = 100;
+      const opponentPokemonHP = 100;
+
+      const turn =
+        (userPokemon.speed ?? 0) > (opponentPokemon.speed ?? 0)
+          ? 'user'
+          : 'opponent';
+
+      const fightId = randomUUID();
+      const fightState: FightState = {
+        fightId,
+        userPokemon: userPokemon,
+        opponentPokemon: opponentPokemon,
+        userPokemonHP,
+        opponentPokemonHP,
+        turn,
+        battleLog: [],
+        winnerId: null,
+        status: 'in-progress',
+      };
+
+      await this.fightRepo.createFight(fightState);
+
+      return {
+        fightId, // include fightId for frontend/attack endpoint
+        user: userPokemon,
+        opponent: opponentPokemon,
+        starter: turn,
+      };
+    } catch (error) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  }
+
+  async attack(dto: AttackDto) {
+    const fight = await this.fightRepo.getFight(dto.fightId);
+    if (!fight) {
+      throw new NotFoundException('Fight not found');
+    }
+    if (fight.status !== 'in-progress') {
+      throw new Error('Fight is already finished');
+    }
+
+    const isUserTurn = fight.turn === 'user';
+    const attacker = isUserTurn ? fight.userPokemon : fight.opponentPokemon;
+    const defender = isUserTurn ? fight.opponentPokemon : fight.userPokemon;
+    const defenderHPKey = isUserTurn ? 'opponentPokemonHP' : 'userPokemonHP';
+
+    const maxLife = defender.HP || defender.HP || 100;
+    const currentLife = fight[defenderHPKey];
+    const power = attacker.power || attacker.powerLevel || 50;
+    const newLife = calculateNewLifeBar(power, currentLife, maxLife);
+
+    const logEntry = {
+      turn: fight.turn,
+      move: dto.move,
+      damage: currentLife - newLife,
+      result: newLife <= 0 ? 'KO' : 'hit',
+      timestamp: new Date(),
+    };
+
+    const updatedFight = updateFightAfterAttack(
+      fight,
+      newLife,
+      logEntry,
+      isUserTurn,
+    );
+
+    await this.fightRepo.updateFight(dto.fightId, updatedFight);
+
+    return {
+      lifebar: newLife,
+      turn: updatedFight.turn,
+      log: logEntry,
+      status: updatedFight.status || fight.status,
+      winnerId: updatedFight.winnerId,
+    };
+  }
+
+  async catchPokemon(dto: CatchDto) {
+    const fight = await this.fightRepo.getFight(dto.fightId);
+    if (!fight) {
+      throw new NotFoundException('Fight not found');
+    }
+    // TODO: Implement catch logic and update fight state
+    // Example: await this.fightRepo.updateFight(dto.fightId, { ...updates });
+    return fight;
+  }
+}

--- a/src/myPokemons/dto/create-my-pokemon.dto.ts
+++ b/src/myPokemons/dto/create-my-pokemon.dto.ts
@@ -1,0 +1,45 @@
+import { IsInt, IsString, IsOptional, IsArray } from 'class-validator';
+
+export class CreateMyPokemonDto {
+  @IsInt()
+  id: number;
+
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  image?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsInt()
+  @IsOptional()
+  powerLevel?: number;
+
+  @IsInt()
+  @IsOptional()
+  HP?: number;
+
+  @IsString()
+  @IsOptional()
+  height?: string;
+
+  @IsString()
+  @IsOptional()
+  weight?: string;
+
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @IsArray()
+  @IsOptional()
+  abilities?: string[];
+
+  @IsInt()
+  @IsOptional()
+  speed?: number;
+}

--- a/src/myPokemons/my-pokemon.schema.ts
+++ b/src/myPokemons/my-pokemon.schema.ts
@@ -1,0 +1,18 @@
+import { Schema } from 'mongoose';
+
+export const MyPokemonSchema = new Schema(
+  {
+    id: { type: Number, required: true, unique: true },
+    name: { type: String, required: true },
+    image: { type: String },
+    description: { type: String },
+    powerLevel: { type: Number },
+    HP: { type: Number },
+    height: { type: String },
+    weight: { type: String },
+    category: { type: String },
+    abilities: [{ type: String }],
+    speed: { type: Number },
+  },
+  { collection: 'myPokemons' },
+);

--- a/src/myPokemons/my-pokemons.controller.ts
+++ b/src/myPokemons/my-pokemons.controller.ts
@@ -1,10 +1,22 @@
-import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
 import { MyPokemonsService } from './my-pokemons.service';
 import { Pokemon } from '../types/pokemon.types';
 import { CreateMyPokemonDto } from './dto/create-my-pokemon.dto';
+import { handleControllerError } from '../common/handle-controller-error';
 
 @Controller('my-pokemons')
 export class MyPokemonsController {
+  private readonly logger = new Logger(MyPokemonsController.name);
+
   constructor(private readonly service: MyPokemonsService) {}
 
   @Get()
@@ -15,28 +27,63 @@ export class MyPokemonsController {
     @Query('order') order?: string,
     @Query('search') search?: string,
   ): Promise<Pokemon[]> {
-    return this.service.getAll(
-      limit ? Number(limit) : undefined,
-      offset ? Number(offset) : undefined,
-      sort,
-      order,
-      search,
-    );
+    try {
+      const result = await this.service.getAll(
+        limit ? Number(limit) : undefined,
+        offset ? Number(offset) : undefined,
+        sort,
+        order,
+        search,
+      );
+      this.logger.log(
+        `Fetched my pokemons (count: ${result.length}) with params: limit=${limit}, offset=${offset}, sort=${sort}, order=${order}, search=${search}`,
+      );
+      return result;
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid query parameters',
+        'Failed to fetch my pokemons',
+      );
+    }
   }
 
   @Get('count')
   async count(): Promise<{ count: number }> {
-    const count = await this.service.count();
-    return { count };
+    try {
+      const count = await this.service.count();
+      this.logger.log(`Fetched my pokemons count: ${count}`);
+      return { count };
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        undefined,
+        'Invalid query parameters',
+        'Failed to fetch my pokemons count',
+      );
+    }
   }
 
   @Get(':id')
   async getById(@Param('id') id: string): Promise<Pokemon | null> {
-    return this.service.getById(Number(id));
+    try {
+      const pokemon = await this.service.getById(Number(id));
+      if (!pokemon) {
+        throw new NotFoundException(`Pokemon with id ${id} not found`);
+      }
+      this.logger.log(`Fetched my pokemon with id: ${id}`);
+      return pokemon;
+    } catch (error) {
+      handleControllerError(
+        error,
+        this.logger,
+        `Pokemon with id ${id} not found`,
+        'Invalid ID parameter',
+        'Failed to fetch my pokemon',
+      );
+    }
   }
-
-  // @Post()
-  // async create(@Body() pokemon: CreateMyPokemonDto): Promise<Pokemon> {
-  //   return this.service.create(pokemon);
-  // }
 }

--- a/src/myPokemons/my-pokemons.controller.ts
+++ b/src/myPokemons/my-pokemons.controller.ts
@@ -35,8 +35,8 @@ export class MyPokemonsController {
     return this.service.getById(Number(id));
   }
 
-  @Post()
-  async create(@Body() pokemon: CreateMyPokemonDto): Promise<Pokemon> {
-    return this.service.create(pokemon);
-  }
+  // @Post()
+  // async create(@Body() pokemon: CreateMyPokemonDto): Promise<Pokemon> {
+  //   return this.service.create(pokemon);
+  // }
 }

--- a/src/myPokemons/my-pokemons.controller.ts
+++ b/src/myPokemons/my-pokemons.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
+import { MyPokemonsService } from './my-pokemons.service';
+import { Pokemon } from '../types/pokemon.types';
+import { CreateMyPokemonDto } from './dto/create-my-pokemon.dto';
+
+@Controller('my-pokemons')
+export class MyPokemonsController {
+  constructor(private readonly service: MyPokemonsService) {}
+
+  @Get()
+  async getAll(
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('sort') sort?: string,
+    @Query('order') order?: string,
+    @Query('search') search?: string,
+  ): Promise<Pokemon[]> {
+    return this.service.getAll(
+      limit ? Number(limit) : undefined,
+      offset ? Number(offset) : undefined,
+      sort,
+      order,
+      search,
+    );
+  }
+
+  @Get('count')
+  async count(): Promise<{ count: number }> {
+    const count = await this.service.count();
+    return { count };
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<Pokemon | null> {
+    return this.service.getById(Number(id));
+  }
+
+  @Post()
+  async create(@Body() pokemon: CreateMyPokemonDto): Promise<Pokemon> {
+    return this.service.create(pokemon);
+  }
+}

--- a/src/myPokemons/my-pokemons.module.ts
+++ b/src/myPokemons/my-pokemons.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MyPokemonSchema } from './my-pokemon.schema';
+import { MyPokemonsRepo } from './my-pokemons.repo';
+import { MyPokemonsService } from './my-pokemons.service';
+import { MyPokemonsController } from './my-pokemons.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: 'MyPokemon', schema: MyPokemonSchema }]),
+  ],
+  controllers: [MyPokemonsController],
+  providers: [MyPokemonsService, MyPokemonsRepo],
+  exports: [MyPokemonsService],
+})
+export class MyPokemonsModule {}

--- a/src/myPokemons/my-pokemons.repo.ts
+++ b/src/myPokemons/my-pokemons.repo.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Pokemon } from '../types/pokemon.types';
+
+@Injectable()
+export class MyPokemonsRepo {
+  constructor(
+    @InjectModel('MyPokemon')
+    private readonly myPokemonModel: Model<Pokemon>,
+  ) {}
+
+  async findAll(
+    limit?: number,
+    offset?: number,
+    sort?: string,
+    order?: string,
+    search?: string,
+  ) {
+    let filter: any = {};
+    if (search) {
+      filter.name = { $regex: search, $options: 'i' };
+    }
+    let query = this.myPokemonModel.find(filter);
+    if (sort) {
+      const sortOrder = order === 'desc' ? -1 : 1;
+      query = query.sort({ [sort]: sortOrder });
+    }
+    if (typeof offset === 'number') query = query.skip(offset);
+    if (typeof limit === 'number') query = query.limit(limit);
+    return query.exec();
+  }
+
+  async findById(id: number) {
+    return this.myPokemonModel.findOne({ id }).exec();
+  }
+
+  async count() {
+    return this.myPokemonModel.countDocuments().exec();
+  }
+
+  async create(pokemon: Partial<Pokemon>) {
+    const created = new this.myPokemonModel(pokemon);
+    return created.save();
+  }
+}

--- a/src/myPokemons/my-pokemons.repo.ts
+++ b/src/myPokemons/my-pokemons.repo.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, FilterQuery } from 'mongoose';
 import { Pokemon } from '../types/pokemon.types';
 
 @Injectable()
@@ -17,7 +17,7 @@ export class MyPokemonsRepo {
     order?: string,
     search?: string,
   ) {
-    let filter: any = {};
+    let filter: FilterQuery<Pokemon> = {};
     if (search) {
       filter.name = { $regex: search, $options: 'i' };
     }

--- a/src/myPokemons/my-pokemons.service.ts
+++ b/src/myPokemons/my-pokemons.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { MyPokemonsRepo } from './my-pokemons.repo';
+import { Pokemon } from '../types/pokemon.types';
+
+@Injectable()
+export class MyPokemonsService {
+  constructor(private readonly repo: MyPokemonsRepo) {}
+
+  async getAll(
+    limit?: number,
+    offset?: number,
+    sort?: string,
+    order?: string,
+    search?: string,
+  ): Promise<Pokemon[]> {
+    return this.repo.findAll(limit, offset, sort, order, search);
+  }
+
+  async getById(id: number): Promise<Pokemon | null> {
+    return this.repo.findById(id);
+  }
+
+  async count(): Promise<number> {
+    return this.repo.count();
+  }
+
+  async create(pokemon: Partial<Pokemon>): Promise<Pokemon> {
+    return this.repo.create(pokemon);
+  }
+}

--- a/src/types/pokemon.types.ts
+++ b/src/types/pokemon.types.ts
@@ -1,4 +1,5 @@
 export type Pokemon = {
+  power: number;
   id: number;
   name: string;
   image?: string;

--- a/src/utiles/calculateNewLifeBar.ts
+++ b/src/utiles/calculateNewLifeBar.ts
@@ -1,0 +1,13 @@
+export function calculateNewLifeBar(
+  power: number,
+  currentLife: number,
+  maxLife: number
+): number {
+  const baseDamage = (power / 100) * (maxLife * 0.25);
+  const randomFactor = Math.random() * (maxLife * 0.05);
+  const damage = Math.max(1, Math.round(baseDamage + randomFactor));
+  const newLife = Math.max(0, currentLife - damage);
+
+  console.log(Math.round(newLife));
+  return Math.round(newLife);
+}

--- a/src/utiles/getRandomOpponentPokemon.ts
+++ b/src/utiles/getRandomOpponentPokemon.ts
@@ -1,0 +1,22 @@
+import { MyPokemonsService } from '../myPokemons/my-pokemons.service';
+import { AllPokemonsService } from '../allPokemons/all-pokemons.service';
+
+export async function getRandomOpponentPokemon(
+  myPokemonsService: MyPokemonsService,
+  allPokemonsService: AllPokemonsService
+): Promise<any> {
+  const userPokemons = await myPokemonsService.getAll();
+  const userPokemonIds = userPokemons.map((p) => p.id);
+  const allPokemons = await allPokemonsService.getAll();
+
+  const availableOpponents = allPokemons.filter(
+    (p) => !userPokemonIds.includes(p.id),
+  );
+  if (availableOpponents.length === 0) {
+    throw new Error('No available opponent pokemons found');
+  }
+
+  return availableOpponents[
+    Math.floor(Math.random() * availableOpponents.length)
+  ];
+}

--- a/src/utiles/updateFightAfterAttack.ts
+++ b/src/utiles/updateFightAfterAttack.ts
@@ -1,0 +1,23 @@
+import { FightState } from '../fight/fight.repo';
+
+export function updateFightAfterAttack(
+  fight: FightState,
+  newLife: number,
+  logEntry: any,
+  isUserTurn: boolean
+) {
+  const defenderHPKey = isUserTurn ? 'opponentPokemonHP' : 'userPokemonHP';
+
+  const updatedFight: Partial<FightState> = {
+    [defenderHPKey]: newLife,
+    battleLog: [...fight.battleLog, logEntry],
+    turn: isUserTurn ? 'opponent' : 'user',
+  };
+
+  if (newLife <= 0) {
+    updatedFight.status = 'finished';
+    updatedFight.winnerId = (isUserTurn ? fight.userPokemon : fight.opponentPokemon).id;
+  }
+
+  return updatedFight;
+}


### PR DESCRIPTION
- Added my-pokemons module (controller, service, repo, DTOs, schema)
- Supports CRUD endpoints: get all, get by id, count, create
- Uses type-safe DTOs and Mongoose models
- Centralized error handling and logging (same as all-pokemons)
- Query params: pagination, sorting, search
- Fully integrated with backend error and success logging